### PR TITLE
Getting current market data via websockets

### DIFF
--- a/Bittrex.Net/Bittrex.Net.csproj
+++ b/Bittrex.Net/Bittrex.Net.csproj
@@ -24,7 +24,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />	
 	<PackageReference Include="System.Net.Http" Version="4.3.3" />		

--- a/Bittrex.Net/Bittrex.Net.csproj
+++ b/Bittrex.Net/Bittrex.Net.csproj
@@ -24,6 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="Microsoft.AspNet.SignalR.Client" Version="2.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />	
 	<PackageReference Include="System.Net.Http" Version="4.3.3" />		
@@ -40,12 +41,6 @@
   
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">	
 	<PackageReference Include="WebSocket4Net" Version="0.15.0" />
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Reference Include="log4net">
-      <HintPath>..\..\..\..\.nuget\packages\log4net\2.0.8\lib\net45-full\log4net.dll</HintPath>
-    </Reference>
   </ItemGroup>
   
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0'">

--- a/Bittrex.Net/BittrexSocketClient.cs
+++ b/Bittrex.Net/BittrexSocketClient.cs
@@ -75,18 +75,18 @@ namespace Bittrex.Net
         #region public
 
         /// <summary>
-        /// set Proxy for Websocket Communication
+        /// set Proxy for Websocket Communication (only use DNS)
         /// </summary>
-        /// <param name="Host"></param>
+        /// <param name="Host">only use DNS not IP</param>
         /// <param name="port"></param>
-        public void setProxy(String Host, int Port)
+        public void SetProxy(String Host, int Port)
         {
             this.ProxyHost = Host;
             this.ProxyPort = Port;
         }
 
         /// <summary>
-        /// Synchronized version of the <see cref="SubscribeToQueryExchangeStateAsync"/> method
+        /// Synchronized version of the <see cref="QueryExchangeStateAsync"/> method
         /// </summary>
         /// <returns></returns>
         public BittrexApiResult<int> QueryExchangeState(string marketName, Action<BittrexExchangeState> onUpdate) => QueryExchangeStateAsync(marketName, onUpdate).Result;

--- a/Bittrex.Net/BittrexSocketClient.cs
+++ b/Bittrex.Net/BittrexSocketClient.cs
@@ -361,7 +361,7 @@ namespace Bittrex.Net
             
             if (connection.State == ConnectionState.Connected)
             {
-                //proxy.Invoke("SubscribeToSummaryDeltas");
+                proxy.Invoke("SubscribeToSummaryDeltas");
 
                 // TODO: add other subscriptions
                 IEnumerable<BittrexExchangeDeltasRegistration> marketRegistrations;

--- a/Bittrex.Net/BittrexSocketClient.cs
+++ b/Bittrex.Net/BittrexSocketClient.cs
@@ -153,12 +153,11 @@ namespace Bittrex.Net
         {
             return await Task.Run(() =>
             {
-                //log.Write(LogVerbosity.Debug, $"Going to subscribe to ExchangeDeltas of {marketName}");
                 if (!CheckConnection())
                     return ThrowErrorMessage<int>(BittrexErrors.GetError(BittrexErrorKey.CantConnectToServer));
 
                 // send subscripte to bittrex
-                SubscribeTpExchangeDeltas(marketName);
+                SubscribeToExchangeDeltas(marketName);
 
                 var registration = new BittrexExchangeDeltasRegistration() { Callback = onUpdate, MarketName = marketName, StreamId = NextStreamId };
                 lock (registrationLock)
@@ -170,7 +169,7 @@ namespace Bittrex.Net
             });
         }
 
-        private void SubscribeTpExchangeDeltas(string marketName)
+        private void SubscribeToExchangeDeltas(string marketName)
         {
             logger.Debug($"Going to subscribe to ExchangeDeltas of {marketName}");
 
@@ -294,7 +293,7 @@ namespace Bittrex.Net
                     Subscription sub = proxy.Subscribe(UpdateEvent);
                     sub.Received += SocketMessage;
 
-                    Subscription subExchangeDelta = proxy.Subscribe("updateExchangeState"); // M=updateExchangeState
+                    Subscription subExchangeDelta = proxy.Subscribe("updateExchangeState");
                     subExchangeDelta.Received += SocketMessageExchangeDelta;
                 }
 
@@ -368,7 +367,7 @@ namespace Bittrex.Net
                 marketRegistrations = registrations.OfType<BittrexExchangeDeltasRegistration>();
                 foreach (var registration in marketRegistrations)
                 {
-                    SubscribeTpExchangeDeltas(registration.MarketName);
+                    SubscribeToExchangeDeltas(registration.MarketName);
                 }
 
                 return true;
@@ -394,14 +393,12 @@ namespace Bittrex.Net
                 foreach (var update in marketRegistrations.Where(r => r.MarketName == StreamData.MarketName))
                 {
                     // don't use parallel to keep right timing order
-                    //Parallel.ForEach(StreamData.Fills, data =>
                     foreach (BittrexOrderBookFill data in StreamData.Fills)
                     {
                         data.MarketName = StreamData.MarketName;
 
                         update.Callback(data);
                     }
-                    //});
                 }
             }
             catch (Exception e)

--- a/Bittrex.Net/BittrexSocketClient.cs
+++ b/Bittrex.Net/BittrexSocketClient.cs
@@ -374,7 +374,10 @@ namespace Bittrex.Net
             {
                 connection.Start().Wait();
             }
-            catch (Exception) { }
+            catch (Exception ex)
+            {
+                log.Write(LogVerbosity.Debug, ex.ToString());
+            }
             waitEvent.WaitOne();
             connection.StateChanged -= waitDelegate;
             

--- a/Bittrex.Net/BittrexSocketClient.cs
+++ b/Bittrex.Net/BittrexSocketClient.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Net;
 using System.Threading;
@@ -13,9 +12,7 @@ using Newtonsoft.Json.Linq;
 using Bittrex.Net.Interfaces;
 using Microsoft.AspNet.SignalR.Client;
 using Microsoft.AspNet.SignalR.Client.Hubs;
-using System.Reflection;
 using Bittrex.Net.Sockets;
-using log4net;
 
 namespace Bittrex.Net
 {
@@ -27,8 +24,6 @@ namespace Bittrex.Net
 
         private const string HubName = "coreHub";
         private const string UpdateEvent = "updateSummaryState";
-
-        private ILog logger = LogManager.GetLogger(typeof(BittrexSocketClient));
 
         private static Interfaces.IHubConnection connection;
         private static IHubProxy proxy;
@@ -171,7 +166,7 @@ namespace Bittrex.Net
 
         private void SubscribeToExchangeDeltas(string marketName)
         {
-            logger.Debug($"Going to subscribe to ExchangeDeltas of {marketName}");
+            log.Write(LogVerbosity.Debug, $"Going to subscribe to ExchangeDeltas of {marketName}");
 
             proxy.Invoke("SubscribeToExchangeDeltas", marketName);
         }
@@ -313,7 +308,7 @@ namespace Bittrex.Net
                 var CookieList = new List<Cookie>();
                 foreach (Cookie cookie in CC)
                 {
-                    logger.Debug(cookie.ToString());
+                    log.Write(LogVerbosity.Debug, cookie.ToString());
 //#if NETSTANDARD
                     // https://stackoverflow.com/questions/18667931/httpwebrequest-add-cookie-to-cookiecontainer-argumentexception-parameternam
                     // cookieContainer.Add(new Cookie(cookie.Name, cookie.Value) { Domain = new Uri(SocketAddress).Host });

--- a/Bittrex.Net/BittrexSocketClient.cs
+++ b/Bittrex.Net/BittrexSocketClient.cs
@@ -93,6 +93,9 @@ namespace Bittrex.Net
 
         /// <summary>
         /// get basic/initial info of a specific market
+        /// 500 Buys
+        /// 100 Fills
+        /// 500 Sells
         /// </summary>
         /// <param name="marketName">The name of the market to subscribe on</param>
         /// <param name="onUpdate">The update event handler</param>

--- a/Bittrex.Net/BittrexSocketClient.cs
+++ b/Bittrex.Net/BittrexSocketClient.cs
@@ -60,6 +60,10 @@ namespace Bittrex.Net
         public static event Action ConnectionLost;
         public static event Action ConnectionRestored;
 
+        public string ProxyHost { get; set; }
+        public int ProxyPort { get; set; }
+
+
         #region ctor
         public BittrexSocketClient()
         {
@@ -69,6 +73,18 @@ namespace Bittrex.Net
 
         #region methods
         #region public
+
+        /// <summary>
+        /// set Proxy for Websocket Communication
+        /// </summary>
+        /// <param name="Host"></param>
+        /// <param name="port"></param>
+        public void setProxy(String Host, int Port)
+        {
+            this.ProxyHost = Host;
+            this.ProxyPort = Port;
+        }
+
         /// <summary>
         /// Synchronized version of the <see cref="SubscribeToMarketDeltaStreamAsync"/> method
         /// </summary>
@@ -277,7 +293,16 @@ namespace Bittrex.Net
             {
                 if (connection == null)
                 {
-                    connection = ConnectionFactory.Create(SocketAddress);
+                    if (this.ProxyHost != "" && this.ProxyPort != 0)
+                    {
+                        connection = ConnectionFactory.Create(SocketAddress, this.ProxyHost, this.ProxyPort);
+                    }
+                    else
+                    {
+                        connection = ConnectionFactory.Create(SocketAddress);
+                    }
+
+
                     proxy = connection.CreateHubProxy(HubName);
 
                     connection.Closed += SocketClosed;

--- a/Bittrex.Net/BittrexSocketClient.cs
+++ b/Bittrex.Net/BittrexSocketClient.cs
@@ -327,28 +327,6 @@ namespace Bittrex.Net
                 if (cookieContainer == null)
                     return false;
 
-                // this fixes missing cookies and prints them
-                //var CC = cookieContainer.GetCookies(new Uri(SocketAddress));
-                var CC = cookieContainer.GetCookies(new Uri(BaseAddress));
-                var CookieList = new List<Cookie>();
-                foreach (Cookie cookie in CC)
-                {
-                    log.Write(LogVerbosity.Debug, cookie.ToString());
-//#if NETSTANDARD
-                    // https://stackoverflow.com/questions/18667931/httpwebrequest-add-cookie-to-cookiecontainer-argumentexception-parameternam
-                    // cookieContainer.Add(new Cookie(cookie.Name, cookie.Value) { Domain = new Uri(SocketAddress).Host });
-                    CookieList.Add(new Cookie(cookie.Name, cookie.Value) { Domain = new Uri(SocketAddress).Host });
-                }
-
-                // add cookies to container (with socket domain)
-                cookieContainer = new CookieContainer();
-                foreach (Cookie cookie in CookieList)
-                {
-                    // https://stackoverflow.com/questions/18667931/httpwebrequest-add-cookie-to-cookiecontainer-argumentexception-parameternam
-                    cookieContainer.Add(cookie);
-//#endif
-                }
-
                 connection.Cookies = cookieContainer;
                 connection.UserAgent = GetUserAgentString();
                 log.Write(LogVerbosity.Debug, "CloudFlare cookies retrieved, retrying connection");

--- a/Bittrex.Net/Interfaces/IConnectionFactory.cs
+++ b/Bittrex.Net/Interfaces/IConnectionFactory.cs
@@ -3,5 +3,7 @@
     public interface IConnectionFactory
     {
         IHubConnection Create(string url);
+
+        IHubConnection Create(string url, string proxyDns, int proxyPort);
     }
 }

--- a/Bittrex.Net/Interfaces/IWebSocket.cs
+++ b/Bittrex.Net/Interfaces/IWebSocket.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Net;
 
 namespace Bittrex.Net.Interfaces
 {
@@ -16,5 +17,6 @@ namespace Bittrex.Net.Interfaces
 
         void Open();
         void Close();
+        void setProxy(IWebProxy connectionProxy);
     }
 }

--- a/Bittrex.Net/Objects/BittrexExchangeState.cs
+++ b/Bittrex.Net/Objects/BittrexExchangeState.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Bittrex.Net.Objects
+{
+    public class BittrexExchangeState
+    {
+        public long Nounce { get; set; }
+
+        // only has Quantity and Rate
+        public List<BittrexOrderBookEntry> Buys { get; set; }
+
+        // has additional not added fileds like id, Total, FillType(Fill, ParitalFill)
+        public List<BittrexOrderBookFillExchangeState> Fills { get; set; }
+
+        // only has Quantity and Rate
+        public List<BittrexOrderBookEntry> Sells { get; set; }
+
+        // API gives always NULL
+        public String MarketName { get; set; }
+    }
+
+    // TODO: find meaning of field names
+    public class BittrexOrderBookFillExchangeState
+    {
+        public FillTypeExchangeState FillType { get; set; }
+        public long id { get; set; }
+        public OrderType OrderType { get; set; }
+        public decimal Price { get; set; }
+        public decimal Quantity { get; set; }
+        public DateTime TimeStamp { get; set; }
+        public decimal Total { get; set; }
+    }
+
+    
+    public enum FillTypeExchangeState
+    {
+        FILL,
+        PARTIAL_FILL
+    }
+    
+}

--- a/Bittrex.Net/Objects/BittrexOrderBook.cs
+++ b/Bittrex.Net/Objects/BittrexOrderBook.cs
@@ -29,8 +29,21 @@ namespace Bittrex.Net.Objects
         public decimal Rate { get; set; }
 
         /// <summary>
-        /// unkown (used by stream)
+        /// how to handle data (used by stream)
         /// </summary>
-        public int Type { get; set; }
+        public OrderBookEntryType Type { get; set; }
+    }
+
+    /// <summary>
+    /// https://github.com/JKorf/Bittrex.Net/pull/42#discussion_r160122966
+    /// Type 0 – you need to add this entry into your orderbook. There were no orders at matching price before.
+    /// Type 1 – you need to delete this entry from your orderbook.This entry no longer exists (no orders at matching price)
+    /// Type 2 – you need to edit this entry.There are different number of orders at this price.
+    /// </summary>
+    public enum OrderBookEntryType
+    {
+        NewEntry = 0,
+        RemoveEntry = 1,
+        UpdateEntry = 2
     }
 }

--- a/Bittrex.Net/Objects/BittrexStreamRegistration.cs
+++ b/Bittrex.Net/Objects/BittrexStreamRegistration.cs
@@ -21,6 +21,7 @@ namespace Bittrex.Net.Objects
 
     internal class BittrexExchangeStateRegistration : BittrexRegistration
     {
+        // TODO: work out the data model given by the websocket
         public Action<Object> Callback { get; set; }
         public string MarketName { get; set; }
     }

--- a/Bittrex.Net/Objects/BittrexStreamRegistration.cs
+++ b/Bittrex.Net/Objects/BittrexStreamRegistration.cs
@@ -28,7 +28,7 @@ namespace Bittrex.Net.Objects
 
     internal class BittrexExchangeDeltasRegistration : BittrexRegistration
     {
-        public Action<BittrexOrderBookFill> Callback { get; set; }
+        public Action<BittrexStreamExchangeState> Callback { get; set; }
         public string MarketName { get; set; }
     }
 }

--- a/Bittrex.Net/Objects/BittrexStreamRegistration.cs
+++ b/Bittrex.Net/Objects/BittrexStreamRegistration.cs
@@ -19,13 +19,6 @@ namespace Bittrex.Net.Objects
         public string MarketName { get; set; }
     }
 
-    internal class BittrexExchangeStateRegistration : BittrexRegistration
-    {
-        // TODO: work out the data model given by the websocket
-        public Action<Object> Callback { get; set; }
-        public string MarketName { get; set; }
-    }
-
     internal class BittrexExchangeDeltasRegistration : BittrexRegistration
     {
         public Action<BittrexStreamExchangeState> Callback { get; set; }

--- a/Bittrex.Net/Sockets/BittrexHubConnection.cs
+++ b/Bittrex.Net/Sockets/BittrexHubConnection.cs
@@ -63,7 +63,6 @@ namespace Bittrex.Net.Sockets
         {
             var client = new HttpClientWithUserAgent();
             var autoTransport = new AutoTransport(client, new IClientTransport[] {
-                // new LongPollingTransport(client), // bittex is not using this
                 new WebsocketCustomTransport(client),
             });
             connection.TransportConnectTimeout = new TimeSpan(0, 0, 10);

--- a/Bittrex.Net/Sockets/BittrexHubConnection.cs
+++ b/Bittrex.Net/Sockets/BittrexHubConnection.cs
@@ -14,9 +14,6 @@ namespace Bittrex.Net.Sockets
         public BittrexHubConnection(HubConnection connection)
         {
             this.connection = connection;
-
-            var webProxy = new WebProxy(new Uri("localhost:8888"));
-            //this.connection.Proxy = webProxy;
         }
 
         public ConnectionState State => connection.State;
@@ -66,7 +63,7 @@ namespace Bittrex.Net.Sockets
         {
             var client = new HttpClientWithUserAgent();
             var autoTransport = new AutoTransport(client, new IClientTransport[] {
-                //new LongPollingTransport(client),
+                // new LongPollingTransport(client), // bittex is not using this
                 new WebsocketCustomTransport(client),
             });
             connection.TransportConnectTimeout = new TimeSpan(0, 0, 10);

--- a/Bittrex.Net/Sockets/ConnectionFactory.cs
+++ b/Bittrex.Net/Sockets/ConnectionFactory.cs
@@ -8,10 +8,9 @@ namespace Bittrex.Net.Sockets
         public IHubConnection Create(string url)
         {
             HubConnection hubConnection = new HubConnection(
-                "https://socket.bittrex.com/signalr/", // https://socket.bittrex.com/signalr/connect
+                "https://socket.bittrex.com/signalr/",
                 useDefaultUrl: false,
                 queryString: "tid=1"
-                // ,queryString: "transport=webSockets&clientProtocol=1.5"
                 );
             return new BittrexHubConnection(hubConnection);
         }

--- a/Bittrex.Net/Sockets/ConnectionFactory.cs
+++ b/Bittrex.Net/Sockets/ConnectionFactory.cs
@@ -8,7 +8,7 @@ namespace Bittrex.Net.Sockets
         public IHubConnection Create(string url)
         {
             HubConnection hubConnection = new HubConnection(
-                url,
+                url + "signalr",
                 useDefaultUrl: false,
                 queryString: "tid=1"
                 );

--- a/Bittrex.Net/Sockets/ConnectionFactory.cs
+++ b/Bittrex.Net/Sockets/ConnectionFactory.cs
@@ -1,4 +1,5 @@
-﻿using Bittrex.Net.Interfaces;
+﻿using System.Net;
+using Bittrex.Net.Interfaces;
 using Microsoft.AspNet.SignalR.Client;
 
 namespace Bittrex.Net.Sockets
@@ -7,12 +8,25 @@ namespace Bittrex.Net.Sockets
     {
         public IHubConnection Create(string url)
         {
+            HubConnection hubConnection = createHubConnection(url);
+            return new BittrexHubConnection(hubConnection);
+        }
+
+        public IHubConnection Create(string url, string proxyDns, int proxyPort)
+        {
+            HubConnection hubConnection = createHubConnection(url);
+            hubConnection.Proxy = new WebProxy(proxyDns, proxyPort);
+            return new BittrexHubConnection(hubConnection);
+        }
+
+        private static HubConnection createHubConnection(string url)
+        {
             HubConnection hubConnection = new HubConnection(
                 url + "signalr",
                 useDefaultUrl: false,
                 queryString: "tid=1"
-                );
-            return new BittrexHubConnection(hubConnection);
+            );
+            return hubConnection;
         }
     }
 }

--- a/Bittrex.Net/Sockets/ConnectionFactory.cs
+++ b/Bittrex.Net/Sockets/ConnectionFactory.cs
@@ -22,9 +22,7 @@ namespace Bittrex.Net.Sockets
         private static HubConnection createHubConnection(string url)
         {
             HubConnection hubConnection = new HubConnection(
-                url + "signalr",
-                useDefaultUrl: false,
-                queryString: "tid=1"
+                url + "signalr"
             );
             return hubConnection;
         }

--- a/Bittrex.Net/Sockets/ConnectionFactory.cs
+++ b/Bittrex.Net/Sockets/ConnectionFactory.cs
@@ -8,7 +8,7 @@ namespace Bittrex.Net.Sockets
         public IHubConnection Create(string url)
         {
             HubConnection hubConnection = new HubConnection(
-                "https://socket.bittrex.com/signalr/",
+                url,
                 useDefaultUrl: false,
                 queryString: "tid=1"
                 );

--- a/Bittrex.Net/Sockets/Websocket4Net.cs
+++ b/Bittrex.Net/Sockets/Websocket4Net.cs
@@ -97,9 +97,9 @@ namespace Bittrex.Net.Sockets
                 return;
             }
 
-            string host = connectionProxy.GetProxy(null).Host;
-            int proxyPort = connectionProxy.GetProxy(null).Port;
-            // proxy websocket stuff through fiddler
+            string host = proxy.Host;
+            int proxyPort = proxy.Port;
+
             if (host != "" && proxyPort != 0)
             {
                 socket.Security.AllowNameMismatchCertificate = true;

--- a/Bittrex.Net/Sockets/Websocket4Net.cs
+++ b/Bittrex.Net/Sockets/Websocket4Net.cs
@@ -22,17 +22,14 @@ namespace Bittrex.Net.Sockets
 
         public Websocket4Net(string url, IDictionary<string, string> cookies, IDictionary<string, string> headers)
         {
-            //url = "wss://echo.websocket.org";
-
             socket = new WebSocket(url, cookies: cookies.ToList(), customHeaderItems: headers.ToList(), receiveBufferSize: 2048, sslProtocols: SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls);
             socket.NoDelay = true;
-            socket.Security.AllowNameMismatchCertificate = true;
-            socket.Security.AllowUnstrustedCertificate = true;
 
-            // User-Agent: SignalR.Client.NetStandard/2.2.2.0 (Unknown OS)
-
-            var proxy = new HttpConnectProxy(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 8888));
-            socket.Proxy = (SuperSocket.ClientEngine.IProxyConnector)proxy;
+            // proxy websocket stuff through fiddler
+            // socket.Security.AllowNameMismatchCertificate = true;
+            // socket.Security.AllowUnstrustedCertificate = true;
+            // var proxy = new HttpConnectProxy(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 8888));
+            // socket.Proxy = (SuperSocket.ClientEngine.IProxyConnector)proxy;
 
             socket.Error += HandleError;
             socket.Opened += HandleOpen;

--- a/Bittrex.Net/Sockets/Websocket4Net.cs
+++ b/Bittrex.Net/Sockets/Websocket4Net.cs
@@ -48,7 +48,8 @@ namespace Bittrex.Net.Sockets
 
         private void HandleClose(object sender, EventArgs e)
         {
-            foreach (var handler in closehandlers)
+            // List recreation as workaround so that collection does not get modified on foreach
+            foreach (Action handler in new List<Action>(closehandlers))
                 handler();
         }
 

--- a/Bittrex.Net/Sockets/Websocket4Net.cs
+++ b/Bittrex.Net/Sockets/Websocket4Net.cs
@@ -104,7 +104,6 @@ namespace Bittrex.Net.Sockets
             {
                 socket.Security.AllowNameMismatchCertificate = true;
                 socket.Security.AllowUnstrustedCertificate = true;
-                //socket.Proxy = new HttpConnectProxy(new IPEndPoint(IPAddress.Parse("127.0.0.1"), 8888));
                 socket.Proxy = new HttpConnectProxy(new DnsEndPoint(host, proxyPort));
             }
         }

--- a/Bittrex.Net/Sockets/WebsocketCustomTransport.cs
+++ b/Bittrex.Net/Sockets/WebsocketCustomTransport.cs
@@ -171,6 +171,8 @@ namespace Bittrex.Net.Sockets
             _websocket.OnClose += WebSocketOnClosed;
             _websocket.OnMessage += WebSocketOnMessageReceived;
 
+            _websocket.setProxy(_connection.Proxy);
+
             _websocket.Open();
         }
 

--- a/Bittrex.Net/Sockets/WebsocketNative.cs
+++ b/Bittrex.Net/Sockets/WebsocketNative.cs
@@ -101,6 +101,11 @@ namespace Bittrex.Net.Sockets
             HandleClose();
         }
 
+        public void setProxy(IWebProxy connectionProxy)
+        {
+            throw new NotImplementedException();
+        }
+
         public bool IsClosed()
         {
             return socket.State == WebSocketState.Closed;

--- a/Bittrex.Net/Sockets/WebsocketSharp.cs
+++ b/Bittrex.Net/Sockets/WebsocketSharp.cs
@@ -49,11 +49,8 @@ namespace Bittrex.Net.Sockets
 
         private void HandleClose(object sender, CloseEventArgs e)
         {
-            // workaround so that collection does not get modified on foreach
-            List<Action> handlers = new List<Action>();
-            handlers.AddRange(closehandlers);
-
-            foreach (Action handler in handlers)
+            // List recreation as workaround so that collection does not get modified on foreach
+            foreach (Action handler in new List<Action>(closehandlers))
                 handler();
         }
 

--- a/Bittrex.Net/Sockets/WebsocketSharp.cs
+++ b/Bittrex.Net/Sockets/WebsocketSharp.cs
@@ -100,7 +100,7 @@ namespace Bittrex.Net.Sockets
 
             string host = proxy.Host;
             int proxyPort = proxy.Port;
-            // proxy websocket stuff through fiddler
+
             if (host != "" && proxyPort != 0)
             {
                 socket.SetProxy(String.Format("http://{0}:{1}", host, proxyPort) , null, null);

--- a/Bittrex.Net/Sockets/WebsocketSharp.cs
+++ b/Bittrex.Net/Sockets/WebsocketSharp.cs
@@ -17,10 +17,10 @@ namespace Bittrex.Net.Sockets
 
         public WebsocketSharp(string url, string cookieHeader, string userAgent)
         {
-            //url = "wss://echo.websocket.org";
             socket = new WebSocket(url);
 
-            socket.SetProxy("http://localhost:8888", null, null);
+            // proxy websocket stuff through fiddler
+            // socket.SetProxy("http://localhost:8888", null, null);
 
             socket.SslConfiguration.EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
             socket.CustomHeaders = new Dictionary<string, string>()

--- a/Bittrex.Net/Sockets/WebsocketSharp.cs
+++ b/Bittrex.Net/Sockets/WebsocketSharp.cs
@@ -2,6 +2,8 @@
 using Bittrex.Net.Interfaces;
 using System;
 using System.Collections.Generic;
+using System.Net;
+using System.Net.Sockets;
 using System.Security.Authentication;
 using WebSocketSharp;
 
@@ -18,9 +20,6 @@ namespace Bittrex.Net.Sockets
         public WebsocketSharp(string url, string cookieHeader, string userAgent)
         {
             socket = new WebSocket(url);
-
-            // proxy websocket stuff through fiddler
-            // socket.SetProxy("http://localhost:8888", null, null);
 
             socket.SslConfiguration.EnabledSslProtocols = SslProtocols.Tls12 | SslProtocols.Tls11 | SslProtocols.Tls;
             socket.CustomHeaders = new Dictionary<string, string>()
@@ -84,6 +83,28 @@ namespace Bittrex.Net.Sockets
         public void Close()
         {
             socket.Close();
+        }
+
+        public void setProxy(IWebProxy connectionProxy)
+        {
+            Uri proxy;
+            try
+            {
+                proxy = connectionProxy.GetProxy(socket.Url);
+            }
+            catch (NullReferenceException)
+            {
+                // no proxy is set, we can skip this
+                return;
+            }
+
+            string host = proxy.Host;
+            int proxyPort = proxy.Port;
+            // proxy websocket stuff through fiddler
+            if (host != "" && proxyPort != 0)
+            {
+                socket.SetProxy(String.Format("http://{0}:{1}", host, proxyPort) , null, null);
+            }
         }
 
         public bool IsClosed()


### PR DESCRIPTION
I implemented subscription to market data via websockets. The code is in development stage however I though that maybe someone is interested in this feature.

How to use:
```
subcribtions.Add(socketClient.SubscribeToQueryExchangeState(ProductName, data =>
{
    // Handle data
    logger.Debug(data.ToString());
}));
```

The main changes include the following two methods:
 * SubscribeToQueryExchangeStateAsync -> initial overview of subscribed marked
 * SubscribeToSubscribeToExchangeDeltas -> shows new buy, sell and filled orders

Other changes:
 * "Fix" for missing cookies when using .net Core2.0 and also printing them
 * usage of log4net
 * Fix off errors in 'HandleClose' because list is changed while in foreach
 * added (unkown) tid parameter in query string
 * code snippets to enable proxy for websockets