### PR TITLE
Fix JSON naming issues, split orders for each response

### DIFF
--- a/Bittrex.Net.UnitTests.Core/BittrexClientTests.cs
+++ b/Bittrex.Net.UnitTests.Core/BittrexClientTests.cs
@@ -337,9 +337,9 @@ namespace Bittrex.Net.UnitTests.Core
         public void GetOpenOrders_Should_ReturnOpenOrdersList()
         {
             // arrange
-            var expected = new List<BittrexOrder>()
+            var expected = new List<BittrexOpenOrdersOrder>()
             {
-                new BittrexOrder()
+                new BittrexOpenOrdersOrder
                 {
                     Uuid = null,
                     Quantity = 1.1m,
@@ -356,10 +356,10 @@ namespace Bittrex.Net.UnitTests.Core
                     Limit = 4.4m,
                     Opened = new DateTime(2017, 1,1),
                     OrderUuid = new Guid("3F2504E0-4F89-11D3-9A0C-0305E82C3301"),
-                    PricePerUnit = null,
+                    PricePerUnit = 1.9m,
                     QuantityRemaining = 5.5m
                 },
-                new BittrexOrder()
+                new BittrexOpenOrdersOrder
                 {
                     Uuid = null,
                     Quantity = 6.6m,
@@ -513,10 +513,10 @@ namespace Bittrex.Net.UnitTests.Core
                 Limit = 5.5m,
                 AccountId = "TestId",
                 CommissionReserved = 6.6m,
-                CommissionReservedRemaining = 7.7m,
+                CommissionReserveRemaining = 7.7m,
                 IsOpen = true,
                 Reserved = 8.8m,
-                ReservedRemaining = 9.9m,
+                ReserveRemaining = 9.9m,
                 Sentinel = new Guid("3F2504E0-4F89-11D3-9A0C-0305E82C3301"),
                 Type = OrderTypeExtended.LimitBuy
             };
@@ -534,44 +534,42 @@ namespace Bittrex.Net.UnitTests.Core
         public void GetOrderHistory_Should_ReturnOrderHistoryList()
         {
             // arrange
-            var expected = new List<BittrexOrder>()
+            var expected = new List<BittrexOrderHistoryOrder>
             {
-                new BittrexOrder()
+                new BittrexOrderHistoryOrder
                 {
-                    Uuid = null,
                     Quantity = 1.1m,
                     OrderType = OrderTypeExtended.LimitBuy,
                     Price = 2.2m,
                     Closed = null,
                     CancelInitiated = false,
-                    CommissionPaid = 3.3m,
+                    Commission = 3.3m,
                     Condition = null,
                     ConditionTarget = null,
                     Exchange = "TestMarket",
                     ImmediateOrCancel = false,
                     IsConditional = false,
                     Limit = 4.4m,
-                    Opened = new DateTime(2017, 1, 1),
+                    TimeStamp = new DateTime(2017, 1, 1),
                     OrderUuid = new Guid("3F2504E0-4F89-11D3-9A0C-0305E82C3301"),
-                    PricePerUnit = null,
+                    PricePerUnit = 1.9m,
                     QuantityRemaining = 5.5m
                 },
-                new BittrexOrder()
+                new BittrexOrderHistoryOrder
                 {
-                    Uuid = null,
                     Quantity = 6.6m,
                     OrderType = OrderTypeExtended.LimitSell,
                     Price = 7.7m,
                     Closed = new DateTime(2017, 1, 1),
                     CancelInitiated = true,
-                    CommissionPaid = 8.8m,
+                    Commission = 8.8m,
                     Condition = null,
                     ConditionTarget = null,
                     Exchange = "TestMarket",
                     ImmediateOrCancel = true,
                     IsConditional = false,
                     Limit = 9.9m,
-                    Opened = new DateTime(2017, 1, 1),
+                    TimeStamp = new DateTime(2017, 1, 1),
                     OrderUuid = new Guid("3F2504E0-4F89-11D3-9A0C-0305E82C3301"),
                     PricePerUnit = 11.11m,
                     QuantityRemaining = 10.1m

--- a/Bittrex.Net/BittrexClient.cs
+++ b/Bittrex.Net/BittrexClient.cs
@@ -324,7 +324,7 @@ namespace Bittrex.Net
         /// Gets candle data for a market on a specific interval
         /// </summary>
         /// <param name="market">Market to get candles for</param>
-        /// <param name="market">The candle interval</param>
+        /// <param name="interval">The candle interval</param>
         /// <returns>List of candles</returns>
         public async Task<BittrexApiResult<BittrexCandle[]>> GetCandlesAsync(string market, TickInterval interval)
         {
@@ -347,7 +347,7 @@ namespace Bittrex.Net
         /// Gets candle data for a market on a specific interval
         /// </summary>
         /// <param name="market">Market to get candles for</param>
-        /// <param name="market">The candle interval</param>
+        /// <param name="interval">The candle interval</param>
         /// <returns>List of candles</returns>
         public async Task<BittrexApiResult<BittrexCandle[]>> GetLatestCandleAsync(string market, TickInterval interval)
         {
@@ -418,22 +418,22 @@ namespace Bittrex.Net
         /// Synchronized version of the <see cref="GetOpenOrdersAsync"/> method
         /// </summary>
         /// <returns></returns>
-        public BittrexApiResult<BittrexOrder[]> GetOpenOrders(string market = null) => GetOpenOrdersAsync(market).Result;
+        public BittrexApiResult<BittrexOpenOrdersOrder[]> GetOpenOrders(string market = null) => GetOpenOrdersAsync(market).Result;
 
         /// <summary>
         /// Gets a list of open orders
         /// </summary>
         /// <param name="market">Filter list by market</param>
         /// <returns>List of open orders</returns>
-        public async Task<BittrexApiResult<BittrexOrder[]>> GetOpenOrdersAsync(string market = null)
+        public async Task<BittrexApiResult<BittrexOpenOrdersOrder[]>> GetOpenOrdersAsync(string market = null)
         {
             if (apiKey == null || encryptor == null)
-                return ThrowErrorMessage<BittrexOrder[]>(BittrexErrors.GetError(BittrexErrorKey.NoApiCredentialsProvided));
+                return ThrowErrorMessage<BittrexOpenOrdersOrder[]>(BittrexErrors.GetError(BittrexErrorKey.NoApiCredentialsProvided));
 
             var parameters = new Dictionary<string, string>();
             AddOptionalParameter(parameters, "market", market);
 
-            return await ExecuteRequest<BittrexOrder[]>(GetUrl(OpenOrdersEndpoint, Api, ApiVersion, parameters), true).ConfigureAwait(false);
+            return await ExecuteRequest<BittrexOpenOrdersOrder[]>(GetUrl(OpenOrdersEndpoint, Api, ApiVersion, parameters), true).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -557,21 +557,21 @@ namespace Bittrex.Net
         /// Synchronized version of the <see cref="GetOrderHistoryAsync"/> method
         /// </summary>
         /// <returns></returns>
-        public BittrexApiResult<BittrexOrder[]> GetOrderHistory(string market = null) => GetOrderHistoryAsync(market).Result;
+        public BittrexApiResult<BittrexOrderHistoryOrder[]> GetOrderHistory(string market = null) => GetOrderHistoryAsync(market).Result;
 
         /// <summary>
         /// Gets the order history for the current account
         /// </summary>
         /// <param name="market">Filter on market</param>
         /// <returns>List of orders</returns>
-        public async Task<BittrexApiResult<BittrexOrder[]>> GetOrderHistoryAsync(string market = null)
+        public async Task<BittrexApiResult<BittrexOrderHistoryOrder[]>> GetOrderHistoryAsync(string market = null)
         {
             if (apiKey == null || encryptor == null)
-                return ThrowErrorMessage<BittrexOrder[]>(BittrexErrors.GetError(BittrexErrorKey.NoApiCredentialsProvided));
+                return ThrowErrorMessage<BittrexOrderHistoryOrder[]>(BittrexErrors.GetError(BittrexErrorKey.NoApiCredentialsProvided));
 
             var parameters = new Dictionary<string, string>();
             AddOptionalParameter(parameters, "market", market);
-            return await ExecuteRequest<BittrexOrder[]>(GetUrl(OrderHistoryEndpoint, Api, ApiVersion, parameters), true).ConfigureAwait(false);
+            return await ExecuteRequest<BittrexOrderHistoryOrder[]>(GetUrl(OrderHistoryEndpoint, Api, ApiVersion, parameters), true).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Bittrex.Net/Interfaces/IBittrexClient.cs
+++ b/Bittrex.Net/Interfaces/IBittrexClient.cs
@@ -55,8 +55,8 @@ namespace Bittrex.Net.Interfaces
         BittrexApiResult<object> CancelOrder(Guid guid);
         Task<BittrexApiResult<object>> CancelOrderAsync(Guid guid);
 
-        BittrexApiResult<BittrexOrder[]> GetOpenOrders(string market = null);
-        Task<BittrexApiResult<BittrexOrder[]>> GetOpenOrdersAsync(string market = null);
+        BittrexApiResult<BittrexOpenOrdersOrder[]> GetOpenOrders(string market = null);
+        Task<BittrexApiResult<BittrexOpenOrdersOrder[]>> GetOpenOrdersAsync(string market = null);
 
         BittrexApiResult<BittrexBalance> GetBalance(string currency);
         Task<BittrexApiResult<BittrexBalance>> GetBalanceAsync(string currency);
@@ -73,8 +73,8 @@ namespace Bittrex.Net.Interfaces
         BittrexApiResult<BittrexAccountOrder> GetOrder(Guid guid);
         Task<BittrexApiResult<BittrexAccountOrder>> GetOrderAsync(Guid guid);
 
-        BittrexApiResult<BittrexOrder[]> GetOrderHistory(string market = null);
-        Task<BittrexApiResult<BittrexOrder[]>> GetOrderHistoryAsync(string market = null);
+        BittrexApiResult<BittrexOrderHistoryOrder[]> GetOrderHistory(string market = null);
+        Task<BittrexApiResult<BittrexOrderHistoryOrder[]>> GetOrderHistoryAsync(string market = null);
 
         BittrexApiResult<BittrexWithdrawal[]> GetWithdrawalHistory(string currency = null);
         Task<BittrexApiResult<BittrexWithdrawal[]>> GetWithdrawalHistoryAsync(string currency = null);

--- a/Bittrex.Net/Objects/BittrexAccountOrder.cs
+++ b/Bittrex.Net/Objects/BittrexAccountOrder.cs
@@ -43,17 +43,17 @@ namespace Bittrex.Net.Objects
         /// </summary>
         public decimal Reserved { get; set; }
         /// <summary>
-        /// The remaining reserved currency for this order
+        /// The remaining reserve currency for this order
         /// </summary>
-        public decimal ReservedRemaining { get; set; }
+        public decimal ReserveRemaining { get; set; }
         /// <summary>
         /// The commission reserverd for this order
         /// </summary>
         public decimal CommissionReserved { get; set; }
         /// <summary>
-        /// The remaining commission reserved for this order
+        /// The remaining commission reserve for this order
         /// </summary>
-        public decimal CommissionReservedRemaining { get; set; }
+        public decimal CommissionReserveRemaining { get; set; }
         /// <summary>
         /// The amount of commission paid for this order
         /// </summary>

--- a/Bittrex.Net/Objects/BittrexOpenOrdersOrder.cs
+++ b/Bittrex.Net/Objects/BittrexOpenOrdersOrder.cs
@@ -7,27 +7,27 @@ namespace Bittrex.Net.Objects
     /// <summary>
     /// Information about an order
     /// </summary>
-    public class BittrexOrder
+    public class BittrexOpenOrdersOrder
     {
         /// <summary>
-        /// Guid
+        /// 
         /// </summary>
         public Guid? Uuid { get; set; }
         /// <summary>
-        /// Guid of the order
+        /// The order Guid
         /// </summary>
         public Guid OrderUuid { get; set; }
         /// <summary>
-        /// Market the order is on
+        /// The market the order is on
         /// </summary>
         public string Exchange { get; set; }
         /// <summary>
-        /// The type of the order
+        /// The order type
         /// </summary>
         [JsonConverter(typeof(OrderTypeExtendedConverter))]
         public OrderTypeExtended OrderType { get; set; }
         /// <summary>
-        /// Quantity of the order
+        /// The quantity of the order
         /// </summary>
         public decimal Quantity { get; set; }
         /// <summary>
@@ -35,11 +35,11 @@ namespace Bittrex.Net.Objects
         /// </summary>
         public decimal QuantityRemaining { get; set; }
         /// <summary>
-        /// The limit of the order
+        /// The order limit
         /// </summary>
         public decimal Limit { get; set; }
         /// <summary>
-        /// The commission paid for the order
+        /// The amount of commission paid for this order
         /// </summary>
         public decimal CommissionPaid { get; set; }
         /// <summary>
@@ -47,23 +47,23 @@ namespace Bittrex.Net.Objects
         /// </summary>
         public decimal Price { get; set; }
         /// <summary>
-        /// The price paid per unit
+        /// The price per unit
         /// </summary>
         public decimal? PricePerUnit { get; set; }
         /// <summary>
-        /// Timestamp when the order was opened
+        /// Timestamp when order was opened
         /// </summary>
         public DateTime Opened { get; set; }
         /// <summary>
-        /// Timestamp when the order was closed
+        /// Timestamp when order was closed
         /// </summary>
         public DateTime? Closed { get; set; }
         /// <summary>
-        /// Whether the order is being canceled
+        /// Whether a cancel has begun processing
         /// </summary>
         public bool CancelInitiated { get; set; }
         /// <summary>
-        /// Whether the order was an ImmediateOrCancel order
+        /// Whether it is a ImmediateOrCancel order
         /// </summary>
         public bool ImmediateOrCancel { get; set; }
         /// <summary>
@@ -71,11 +71,11 @@ namespace Bittrex.Net.Objects
         /// </summary>
         public bool IsConditional { get; set; }
         /// <summary>
-        /// The order condition
+        /// The condition of the order
         /// </summary>
         public string Condition { get; set; }
         /// <summary>
-        /// The order condition target
+        /// The condition target of the order
         /// </summary>
         public string ConditionTarget { get; set; }
     }

--- a/Bittrex.Net/Objects/BittrexOrderHistoryOrder.cs
+++ b/Bittrex.Net/Objects/BittrexOrderHistoryOrder.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using Bittrex.Net.Converters;
+using Newtonsoft.Json;
+
+namespace Bittrex.Net.Objects
+{
+    /// <summary>
+    /// Information about an order
+    /// </summary>
+    public class BittrexOrderHistoryOrder
+    {
+        /// <summary>
+        /// Guid of the order
+        /// </summary>
+        public Guid OrderUuid { get; set; }
+        /// <summary>
+        /// Market the order is on
+        /// </summary>
+        public string Exchange { get; set; }
+        /// <summary>
+        /// Timestamp when the order was opened
+        /// </summary>
+        public DateTime TimeStamp { get; set; }
+        /// <summary>
+        /// The type of the order
+        /// </summary>
+        [JsonConverter(typeof(OrderTypeExtendedConverter))]
+        public OrderTypeExtended OrderType { get; set; }
+        /// <summary>
+        /// The limit of the order
+        /// </summary>
+        public decimal Limit { get; set; }
+        /// <summary>
+        /// Quantity of the order
+        /// </summary>
+        public decimal Quantity { get; set; }
+        /// <summary>
+        /// The remaining quantity of the order
+        /// </summary>
+        public decimal QuantityRemaining { get; set; }
+        /// <summary>
+        /// The commission paid for the order
+        /// </summary>
+        public decimal Commission { get; set; }
+        /// <summary>
+        /// The price of the order
+        /// </summary>
+        public decimal Price { get; set; }
+        /// <summary>
+        /// The price paid per unit
+        /// </summary>
+        public decimal PricePerUnit { get; set; }
+        /// <summary>
+        /// Whether the order is conditional
+        /// </summary>
+        public bool IsConditional { get; set; }
+        /// <summary>
+        /// The order condition
+        /// </summary>
+        public string Condition { get; set; }
+        /// <summary>
+        /// The order condition target
+        /// </summary>
+        public string ConditionTarget { get; set; }
+        /// <summary>
+        /// Whether the order was an ImmediateOrCancel order
+        /// </summary>
+        public bool ImmediateOrCancel { get; set; }
+        /// <summary>
+        /// Timestamp when the order was closed
+        /// </summary>
+        public DateTime? Closed { get; set; }
+        /// <summary>
+        /// Whether the order is being canceled
+        /// </summary>
+        public bool CancelInitiated { get; set; }
+    }
+}


### PR DESCRIPTION
* Fix small JSON naming issues, like `CommissionReservedRemaining` > `CommissionReserveRemaining`
* Created an `Order` object for each of the order responses (i.e. `getorder`, `getorderhistory` and `getopenorders`, as they differ slightly

This fixes #46.