### PR TITLE
Avoid blocking the synchronization context

### DIFF
--- a/Bittrex.Net/BittrexSocketClient.cs
+++ b/Bittrex.Net/BittrexSocketClient.cs
@@ -136,7 +136,7 @@ namespace Bittrex.Net
                 });
 
                 return new BittrexApiResult<int>() { Success = true };
-            });
+            }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -166,7 +166,7 @@ namespace Bittrex.Net
                     localRegistrations.Add(registration);
                 }
                 return new BittrexApiResult<int>() { Result = registration.StreamId, Success = true };
-            });
+            }).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -198,7 +198,7 @@ namespace Bittrex.Net
                     localRegistrations.Add(registration);
                 }
                 return new BittrexApiResult<int>() { Result = registration.StreamId, Success = true };
-            });
+            }).ConfigureAwait(false);
         }
 
         private void SubscribeToExchangeDeltas(string marketName)
@@ -236,7 +236,7 @@ namespace Bittrex.Net
                     localRegistrations.Add(registration);
                 }
                 return new BittrexApiResult<int>() { Result = registration.StreamId, Success = true };
-            });
+            }).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Bittrex.Net/Sockets/CustomWebsocket.cs
+++ b/Bittrex.Net/Sockets/CustomWebsocket.cs
@@ -216,7 +216,7 @@ public sealed class CustomWebsocket : WebSocket
             HttpWebRequest httpWebRequest = this.CreateAndConfigureRequest(uri);
 
             cancellationTokenRegistration = cancellationToken.Register(new Action<object>(this.AbortRequest), httpWebRequest, false);
-            httpWebResponse = ((await httpWebRequest.GetResponseAsync()) as HttpWebResponse);
+            httpWebResponse = ((await httpWebRequest.GetResponseAsync().ConfigureAwait(false)) as HttpWebResponse);
 
             string subProtocol = this.ValidateResponse(httpWebRequest, httpWebResponse);
             this.innerWebSocket = WebSocket.CreateClientWebSocket(httpWebResponse.GetResponseStream(), subProtocol, this.options.ReceiveBufferSize, this.options.SendBufferSize, this.options.KeepAliveInterval, false, this.options.GetOrCreateBuffer());

--- a/Bittrex.Net/Sockets/WebsocketCustomTransport.cs
+++ b/Bittrex.Net/Sockets/WebsocketCustomTransport.cs
@@ -197,7 +197,7 @@ namespace Bittrex.Net.Sockets
                     {
                         _connection.OnError(ex);
                     }
-                    await Task.Delay(ReconnectDelay, CancellationToken.None);
+                    await Task.Delay(ReconnectDelay, CancellationToken.None).ConfigureAwait(false);
                 }
                 else
                 {
@@ -226,7 +226,7 @@ namespace Bittrex.Net.Sockets
                 return;
             }
 
-            await DoReconnect();
+            await DoReconnect().ConfigureAwait(false);
         }
 
         private void WebSocketOnError(Exception e)


### PR DESCRIPTION
This fixes a thread deadlock issue i encountered when using the library in a UI app.
Adding `ConfigureAwait(false)` to these calls solved the problem.

And thank you for this great library!