### PR TITLE
Fix order book subscription

### DIFF
--- a/Bittrex.Net/Clients/BittrexSocketClient.cs
+++ b/Bittrex.Net/Clients/BittrexSocketClient.cs
@@ -214,7 +214,8 @@ namespace Bittrex.Net.Clients
                     if (depth == null)
                         return false;
 
-                    return channel.Substring(method.Length + 1, symbol.Length) == symbol && channel.EndsWith(depth);
+                    var segments = channel.Split('_');
+                    return segments.ElementAtOrDefault(1) == symbol && channel.Split('_').ElementAtOrDefault(2) == depth;
                 }
 
                 if (channel.Substring(method.Length + 1, channel.Length - (method.Length + 1)) == symbol)

--- a/Bittrex.Net/Clients/BittrexSocketClient.cs
+++ b/Bittrex.Net/Clients/BittrexSocketClient.cs
@@ -208,6 +208,15 @@ namespace Bittrex.Net.Clients
                     return channel.Substring(method.Length + 1, symbol.Length) == symbol && channel.EndsWith(interval);
                 }
 
+                if (channel.StartsWith("orderbook") && method == "orderbook")
+                {
+                    var depth = tokenData["depth"]?.ToString();
+                    if (depth == null)
+                        return false;
+
+                    return channel.Substring(method.Length + 1, symbol.Length) == symbol && channel.EndsWith(depth);
+                }
+
                 if (channel.Substring(method.Length + 1, channel.Length - (method.Length + 1)) == symbol)
                     return true;
             }


### PR DESCRIPTION
Order book subscription no longer works after the previous fix. Also, if you subscribe to two order book channels with the same symbol but different depth, the message will be sent to the incorrect handler.